### PR TITLE
Use paramConverter of SensioFrameworkExtraBundle in breadcrumb title

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,92 @@ class MyController extends Controller
 
         */
     }
+
 }
+```
+
+#### Title with @ParamConverter
+
+The [@ParamConverter](http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html#annotation-configuration) of the SensioFrameworkExtraBundle convert request parameters like 'id' to objects then injected as controller method arguments:
+
+It is possible to display values ​​of these objects in the breadcrumb.
+
+
+```
+...
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+
+/**
+ * @Route("/book/{id}")
+ * @Breadcrumb("Books")
+ * @Breadcrumb("{book}")
+ */
+public function aShowAction(Book $book)
+{
+
+    /*
+
+    This action will show the following breacrumb trail:
+    Books > result of __toString method of $book's Object
+
+    */
+
+}
+
+/**
+ * @Route("/book/{id}")
+ * @Breadcrumb("Books")
+ * @Breadcrumb("{book.title}")
+ */
+public function bShowAction(Book $book)
+{
+
+    /*
+
+    This action will show the following breacrumb trail:
+    Books > result of getTitle method of $book's Object
+
+    The bundle tries to call the methods : getTitle, hasTitle or isTitle
+
+    */
+
+}
+
+/**
+ * @Route("/book/{id}")
+ * @Breadcrumb("Books")
+ * @Breadcrumb("{book.title:argument1}")
+ */
+public function cShowAction(Book $book)
+{
+
+    /*
+
+    This action will show the following breacrumb trail:
+    Books > result of getTitle('argument1') method of $book's Object
+
+    */
+
+}
+
+/**
+ * @Route("/book/{id}")
+ * @Breadcrumb("Books")
+ * @Breadcrumb("{book.title:argument1: argument2}")
+ */
+public function dShowAction(Book $book)
+{
+
+    /*
+
+    This action will show the following breacrumb trail:
+    Books > result of getTitle('argument1', ' argument2') method of $book's Object
+
+    */
+
+}
+
 ```
 
 ---

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -24,7 +24,7 @@
         </service>
 
         <service id="apy_breadcrumb_trail.annotation.listener" class="%apy_breadcrumb_trail.annotation.listener.class%">
-            <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" />
+            <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" priority="-1" />
             <argument type="service" id="annotation_reader" />
             <argument type="service" id="apy_breadcrumb_trail" />
         </service>


### PR DESCRIPTION
In our projects, we use a lot the paramConverter of SensioFrameworkExtraBundle and so the following syntax:

```
/**
 *
 * @Route("/{slug}", name="customer_show")
 * @Method("GET")
 *
 * @Breadcrumb("Client", route="customer_index")
 */
public function showAction(Customer $customer)
{
    $this->get("apy_breadcrumb_trail")->add($customer->__toString());

    return array('entity' => $customer);
}
```

To show the following breadcrumb :
Client -> Floran

I modify the bundle to use this new syntax :

```
/**
 *
 * @Route("/{slug}", name="customer_show")
 * @Method("GET")
 *
 * @Breadcrumb("Client", route="customer_index")
 * @Breadcrumb("{customer}")
 */
public function showAction(Customer $customer)
{
    return array('entity' => $customer);
}
```

What do you think of this change?
