### PR TITLE
arguments are separated with comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ public function cShowAction(Book $book)
 /**
  * @Route("/book/{id}")
  * @Breadcrumb("Books")
- * @Breadcrumb("{book.title:argument1: argument2}")
+ * @Breadcrumb("{book.title:argument1,argument2}")
  */
 public function dShowAction(Book $book)
 {


### PR DESCRIPTION
when looking at the regex it is not collon but comma that separates parameters
`#\{(?P<variable>\w+).?(?P<function>\w*):?(?P<parameters>(\w|,| )*)\}#`
