### PR TITLE
Add Symfony 4 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,33 @@ jobs:
       - name: Run tests
         run: make test
 
+ test-sf4:
+    name: Test SF4
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 10
+      matrix:
+        php: ['7.2', '7.3', '7.4']
+
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@1.7.0
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: xdebug
+          ini-values: xdebug.overload_var_dump=1
+          extensions: mbstring, intl
+          tools: prestissimo
+
+      - name: Setup Problem Matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run tests
+        run: make test-sf4
+
  test-lowest:
     name: Test Lowest
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,9 @@ test:
 	composer update --prefer-dist --no-interaction ${COMPOSER_PARAMS}
 	composer test
 
+test-sf4:
+	composer require symfony/framework-bundle:"^4.0" --no-update
+	$(MAKE) test-lowest
+
 test-lowest:
 	COMPOSER_PARAMS='--prefer-lowest' $(MAKE) test


### PR DESCRIPTION
Currently only `^3.0` (--prefer lowest) and the latest `^5.0` is being tests.
I have personally ran into quite some bugs, that only appear when running 4.x, so I suggest adding it to the build matrix