### PR TITLE
Fixed autowiring the APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -14,6 +14,8 @@
             </call>
         </service>
 
+        <service id="APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail" alias="apy_breadcrumb_trail" public="true"/>
+
         <service id="apy_breadcrumb_trail.annotation.listener" class="APY\BreadcrumbTrailBundle\EventListener\BreadcrumbListener">
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" priority="-1" />
         </service>


### PR DESCRIPTION
After the latest updates, it broke one of my extensions since autowiring APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail was passing in a fresh new object instead of the existing object. The functionality before created an instance of the service for autowiring. This fix passes in the existing object instead of a new object.