### PR TITLE
Deprecate `apy_breadcrumb_trail` as service id, advocate FQCN in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 composer.lock
+.idea

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -8,14 +8,20 @@
 
         <prototype namespace="APY\BreadcrumbTrailBundle\" resource="../../*" exclude="../../{Annotation,Resources}"/>
 
-        <service id="apy_breadcrumb_trail" class="APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail" public="true">
+        <service id="APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail">
             <call method="setTemplate">
                 <argument>%apy_breadcrumb_trail.template%</argument>
             </call>
         </service>
+        <service id="apy_breadcrumb_trail" alias="APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail" public="true">
+            <deprecated version="1.7" package="APY/APYBreadcrumbTrailBundle">The "%service_id%" service is deprecated, use "%alias_id%" FQCN as service id instead.</deprecated>
+        </service>
 
-        <service id="apy_breadcrumb_trail.annotation.listener" class="APY\BreadcrumbTrailBundle\EventListener\BreadcrumbListener">
+        <service id="APY\BreadcrumbTrailBundle\EventListener\BreadcrumbListener">
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" priority="-1" />
+        </service>
+        <service id="apy_breadcrumb_trail.annotation.listener" alias="APY\BreadcrumbTrailBundle\EventListener\BreadcrumbListener" public="true">
+            <deprecated version="1.7" package="APY/APYBreadcrumbTrailBundle">The "%service_id%" service is deprecated, use "%alias_id%" FQCN as service id instead.</deprecated>
         </service>
     </services>
 </container>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -14,14 +14,14 @@
             </call>
         </service>
         <service id="apy_breadcrumb_trail" alias="APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail" public="true">
-            <deprecated version="1.7" package="APY/APYBreadcrumbTrailBundle">The "%service_id%" service is deprecated, use "%alias_id%" FQCN as service id instead.</deprecated>
+            <deprecated>The "%service_id%" service is deprecated, use "%alias_id%" FQCN as service id instead.</deprecated>
         </service>
 
         <service id="APY\BreadcrumbTrailBundle\EventListener\BreadcrumbListener">
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" priority="-1" />
         </service>
         <service id="apy_breadcrumb_trail.annotation.listener" alias="APY\BreadcrumbTrailBundle\EventListener\BreadcrumbListener" public="true">
-            <deprecated version="1.7" package="APY/APYBreadcrumbTrailBundle">The "%service_id%" service is deprecated, use "%alias_id%" FQCN as service id instead.</deprecated>
+            <deprecated>The "%service_id%" service is deprecated, use "%alias_id%" FQCN as service id instead.</deprecated>
         </service>
     </services>
 </container>

--- a/src/Resources/doc/annotation_configuration.md
+++ b/src/Resources/doc/annotation_configuration.md
@@ -7,7 +7,6 @@ You can add annotations on the controller and the action.
 ## Basic example
 
 ```php
-...
 use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
 
 /**
@@ -53,6 +52,8 @@ The [@ParamConverter](symfony.com/doc/current/bundles/SensioFrameworkExtraBundle
 It is possible to display values ​​of these objects in the breadcrumb.
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+
 /**
  * @Route("/book/{id}")
  * @Breadcrumb("Books")
@@ -69,6 +70,8 @@ Will render the following breadcrumb trail :
 > Books > result of __toString method of $book's Object
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+
 /**
  * @Route("/book/{id}")
  * @Breadcrumb("Books")
@@ -84,9 +87,11 @@ Will render the following breadcrumb trail :
 
 > Books > result of getTitle method of $book's Object
 
-**Note:** The bundle tries to call the methods : getTitle, hasTitle or isTitle.
+**Note:** The bundle tries to call the methods : `getTitle`, `hasTitle` or `isTitle`.
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+
 /**
  * @Route("/book/{id}")
  * @Breadcrumb("Books")
@@ -103,6 +108,8 @@ Will render the following breadcrumb trail :
 > Books > result of getTitle('argument1') method of $book's Object
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+
 /**
  * @Route("/book/{id}")
  * @Breadcrumb("Books")
@@ -123,6 +130,8 @@ Will render the following breadcrumb trail :
 #### Basic example
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+
 /**
  * @Breadcrumb("Level 1", route={"name"="my_route"}
  * @Breadcrumb("Level 2")
@@ -146,6 +155,8 @@ Assume that you have defined the following route :
 and that you are currently on the `my_action_route` with url `http://example.com/var/foo/var1/bar`
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+
 /**
  * @Route("/var/{var}/var1/{var1}", name="my_action_route")
  * @Breadcrumb("Level 1", route={"name"="my_route", "parameters"={"var"=1}})
@@ -165,12 +176,16 @@ Will render the following breadcrumb trail :
 The two following expressions are equivalents :
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+
 /**
  * @Breadcrumb("Level 1", route={"name"="my_route", "parameters"={"var1"=1,"var2"=2}, "absolute"=true})
  */
 ```
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+
 /**
  * @Breadcrumb("Level 1", routeName="my_route", routeParameters={"var1"=1,"var2"=2}, routeAbsolute=true)
  */
@@ -181,6 +196,8 @@ The two following expressions are equivalents :
 Assume your controllers are designed like a REST API and you have a ManyToOne relationship on Book -> Author :
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+
 /**
  * @Route("/books/{book}", name="book", requirements={"book" = "\d+"}) // example: /book/53
  * @Breadcrumb("{book.author.name}", route={"name"="author", "parameters"={"author"="{book.author.id}"}}) // example: /author/15
@@ -204,6 +221,8 @@ public function indexAction(Request $request, Book $book) {
 ### Position
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+
 /**
  * @Breadcrumb("Level 1")
  * @Breadcrumb("Level 2", position=1)
@@ -221,6 +240,8 @@ Will render the following breadcrumb trail :
 ### Attributes
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+
 /**
  * @Breadcrumb("Level 1", attributes={"class": "yellow", "title": "Hello world !"})
  * @Breadcrumb("Level 2")
@@ -246,6 +267,8 @@ Will render the following breadcrumb trail :
 ### Reset the trail
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+
 /**
  * @Breadcrumb("Level 1")
  * @Breadcrumb()

--- a/src/Resources/doc/installation.md
+++ b/src/Resources/doc/installation.md
@@ -1,63 +1,11 @@
 Installation
 ============
 
-## Step 1: Download BreadcrumbTrailBundle
-
-Ultimately, the BreadcrumbTrailBundle files should be downloaded to the
-`vendor/bundles/APY/BreadcrumbTrailBundle` directory.
-
-This can be done in several ways, depending on your preference. The first
-method is the standard Symfony2 method.
-
-**Using the vendors script**
-
-Add the following lines in your `deps` file:
-
 ```
-[BreadcrumbTrailBundle]
-    git=git://github.com/Abhoryo/APYBreadcrumbTrailBundle.git
-    target=bundles/APY/BreadcrumbTrailBundle
+composer require apy/breadcrumbtrail-bundle
 ```
 
-Now, run the vendors script to download the bundle:
-
-```bash
-$ php bin/vendors install
-```
-
-**Using submodules**
-
-If you prefer instead to use git submodules, the run the following:
-
-```bash
-$ git submodule add git://github.com/Abhoryo/APYBreadcrumbTrailBundle.git vendor/bundles/APY/BreadcrumbTrailBundle
-$ git submodule update --init
-```
-
-**Using composer**
-
-run:
-
-`php composer.phar require apy/breadcrumbtrail-bundle`
-
-
-## Step 2: Configure the Autoloader (not with composer)
-
-Add the `APY` namespace to your autoloader:
-
-```php
-<?php
-// app/autoload.php
-
-$loader->registerNamespaces(array(
-    // ...
-    'APY' => __DIR__.'/../vendor/bundles',
-));
-```
-
-## Step 3: Enable the bundles
-
-Finally, enable the bundles in the kernel:
+## Enable the bundle in kernel
 
 ```php
 <?php
@@ -65,9 +13,9 @@ Finally, enable the bundles in the kernel:
 
 public function registerBundles()
 {
-    $bundles = array(
+    $bundles = [
         // ...
         new APY\BreadcrumbTrailBundle\APYBreadcrumbTrailBundle(),
-    );
+    ];
 }
 ```

--- a/src/Resources/doc/override_template.md
+++ b/src/Resources/doc/override_template.md
@@ -32,7 +32,10 @@ Or
  - You can define the template in PHP:
 
 ```php
-$this->get("apy_breadcrumb_trail")->setTemplate('APYBreadcrumbTrailBundle::breadcrumbtrail.html.twig');
+/**
+ * @see \APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail::setTemplate()
+ */
+$trail->setTemplate('APYBreadcrumbTrailBundle::breadcrumbtrail.html.twig');
 ```
 
  - You can define the template when you render the breadcrumb trail in your twig file:

--- a/src/Resources/doc/php_configuration.md
+++ b/src/Resources/doc/php_configuration.md
@@ -1,34 +1,47 @@
 # PHP configuration
 
-Add breadcumbs to the trail with PHP in your controller.
+How to add breadcumbs to the trail in the controller.
 
+## Example 1) Injected via the controller's constructor 
 
-## Basic example (without autowiring)
+Autowiring has to be enabled for the folder where the controller is located. Symfony 4 and higher
+by default have autowiring enabled.
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+use APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail;
+
 /**
  * @Breadcrumb("Level 1")
  * @Breadcrumb("Level 2")
  */
 class MyController extends Controller
 {
+   private $trail;
+   
+   public function __construct(Trail $trail)
+   {
+        $this->trail = $trail;
+    }
+    
     /**
      * @Breadcrumb("Level 3")
      */
     public function myAction()
     {
-        $this->get("apy_breadcrumb_trail")->add('Level 4');
+        $this->trail->add('Level 4');
     }
 }
 ```
 
-Will render the following breadcrumb trail :
+The above example will render the following breadcrumb trail:
 
 > Level 1 > Level 2 > Level 3 > Level 4
 
-## Basic example (with autowiring)
+## Example 2) by autowiring the trail to the action callable)
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
 use APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail;
 
 /**
@@ -51,10 +64,13 @@ Will render the following breadcrumb trail :
 
 > Level 1 > Level 2 > Level 3 > Level 4
 
-## Reference
+## Method reference
 
 ```php
-$this->get("apy_breadcrumb_trail")->add(
+/**
+ * @see APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail::add()
+ */
+$trail->add(
     $breadcrumb_or_title,
     $routeName,
     $routeParameters,
@@ -85,13 +101,16 @@ Assume that you have defined the following route :
 ```
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+use APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail;
+
 /**
  * @Breadcrumb("Level 1")
  */
-public function myAction()
+public function myAction(Trail $trail)
 {
-    $this->get("apy_breadcrumb_trail")->add('Level 2', 'my_route', array("var" => "foo"));
-    $this->get("apy_breadcrumb_trail")->add('Level 3');
+    $trail->add('Level 2', 'my_route', ["var" => "foo"]);
+    $trail->add('Level 3');
 }
 ```
 
@@ -102,14 +121,17 @@ Will render the following breadcrumb trail :
 ## Position
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+use APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail;
+
 /**
  * @Breadcrumb("Level 1")
  */
-public function myAction()
+public function myAction(Trail $trail)
 {
-    $this->get("apy_breadcrumb_trail")->add('Level 2', null, array(), false, 1);
-    $this->get("apy_breadcrumb_trail")->add('Level 3');
-    $this->get("apy_breadcrumb_trail")->add('Level 4', null, array(), false, -1);
+    $trail->add('Level 2', null, [], false, 1);
+    $trail->add('Level 3');
+    $trail->add('Level 4', null, [], false, -1);
 }
 ```
 
@@ -122,15 +144,19 @@ Will render the following breadcrumb trail :
 ### Reset the trail
 
 ```php
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+use APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail;
+
 /**
  * @Breadcrumb("Level 1")
  */
-public function myAction()
+public function myAction(Trail $trail)
 {
-    $this->get("apy_breadcrumb_trail")
+    $trail
         ->reset()
         ->add('Level 2')
-        ->add('Level 3');
+        ->add('Level 3')
+    ;
 }
 ```
 

--- a/src/Resources/doc/rendering.md
+++ b/src/Resources/doc/rendering.md
@@ -2,7 +2,6 @@
 
 
 ```php
-...
 use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
 
 /**

--- a/src/Resources/doc/twig_configuration.md
+++ b/src/Resources/doc/twig_configuration.md
@@ -9,7 +9,7 @@ You just have to add the service in a global variable.
 #app/config/config.yml
 twig:
     globals:
-        breadcrumb_trail: "@apy_breadcrumb_trail"
+        breadcrumb_trail: "@APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail"
 ```
 
 ## Basic example

--- a/tests/BundleInitializationTest.php
+++ b/tests/BundleInitializationTest.php
@@ -11,12 +11,13 @@ class BundleInitializationTest extends BaseBundleTestCase
         return APYBreadcrumbTrailBundle::class;
     }
 
-    public function testServicesAreRegistrated()
+    public function testServicesAreRegisteredToContainer()
     {
         $this->bootKernel();
         $container = $this->getContainer();
 
         $this->assertTrue($container->has('apy_breadcrumb_trail'));
+        $this->assertTrue($container->has('apy_breadcrumb_trail.annotation.listener'));
         $this->assertTrue($container->hasParameter('apy_breadcrumb_trail.template'));
     }
 }


### PR DESCRIPTION
fixes #53