### PR TITLE
Test PHP8 via CI, and allow PHP7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.2', '7.3', '7.4']
 
     steps:
       - name: Set up PHP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.3', '7.4']
-        symfony: ['3.4', '4.4', '5.1']
+        php: ['7.3', '7.4', '8.0']
+        symfony: ['3.4', '4.4', '5.1', '5.2']
 
     steps:
       - name: Set up PHP

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.2",
         "symfony/framework-bundle": "^3.4|^4.0|^5.0",
         "twig/twig": "^1.41|^2.0|^3.0"
     },


### PR DESCRIPTION
PHP 8.0 already was supported on `master` as the composer constraint is `>=7.3`.

This PR 
* adds test coverage for PHP8.0 and Symfony 5.2, and 
* also allows PHP7.2 again as there was no reason to not support it. People themselves should be aware that PHP7.2 is EOL and they should upgrade asap. https://www.php.net/supported-versions.php