### PR TITLE
Test downgrading to PHP7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4']
 
     steps:
       - name: Set up PHP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.1', '7.2', '7.3', '7.4']
 
     steps:
       - name: Set up PHP

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "symfony/framework-bundle": "^3.4|^4.0|^5.0",
         "twig/twig": "^1.41|^2.0|^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.1",
         "symfony/framework-bundle": "^3.4|^4.0|^5.0",
         "twig/twig": "^1.41|^2.0|^3.0"
     },


### PR DESCRIPTION
There seems no reason for not supporting PHP7.2

The reason for not supporting PHP7.1 anymore is twofold:
* the functional test bundle is not available for that version.
* PHP7.1 is EOL