### PR TITLE
Trigger deprecation message on annotations 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4', '8.0']
 
     steps:
       - name: Set up PHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.7
+
+- support breadcrumbs via PHP Attributes
+- deprecate annotations, to be removed in v2.0
+
 #2020-06-10
  - Add PHPUnit to integration test bundle
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require": {
         "php": ">=7.2",
         "symfony/framework-bundle": "^3.4|^4.0|^5.0",
-        "twig/twig": "^1.41|^2.0|^3.0"
+        "twig/twig": "^1.41|^2.0|^3.0",
+        "symfony/deprecation-contracts": "^2.4"
     },
     "scripts": {
         "test": "vendor/bin/simple-phpunit --testdox"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,7 +14,7 @@
         <ini name="intl.default_locale" value="en" />
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=4" />
         <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT " value="1" />
     </php>
 

--- a/src/EventListener/BreadcrumbListener.php
+++ b/src/EventListener/BreadcrumbListener.php
@@ -71,6 +71,9 @@ class BreadcrumbListener
             $classBreadcrumbs = $this->reader->getClassAnnotations($class);
             if ($this->supportsLoadingAttributes()) {
                 $classAttributeBreadcrumbs = $this->getAttributes($class);
+                if (count($classBreadcrumbs) > 0) {
+                    trigger_deprecation('apy/breadcrumb-bundle', '1.7', 'Please replace the annotations in "%s" with attributes. Adding Breadcrumbs via annotations is deprecated and will be removed in v2.0, but luckily your platform supports using Attributes.', $class->name);
+                }
                 if (count($classAttributeBreadcrumbs) > 0) {
                     if (count($classBreadcrumbs) > 0) {
                         throw MixedAnnotationWithAttributeBreadcrumbsException::forClass($class->name);
@@ -85,6 +88,9 @@ class BreadcrumbListener
             $methodBreadcrumbs = $this->reader->getMethodAnnotations($method);
             if ($this->supportsLoadingAttributes()) {
                 $methodAttributeBreadcrumbs = $this->getAttributes($method);
+                if (count($methodBreadcrumbs) > 0) {
+                    trigger_deprecation('apy/breadcrumb-bundle', '1.7', 'Please replace the annotations in "%s" with attributes. Adding Breadcrumbs via annotations is deprecated and will be removed in v2.0, but luckily your platform supports using Attributes.', $class->name.'::'.$method->name);
+                }
                 if (count($methodAttributeBreadcrumbs) > 0) {
                     if (count($methodBreadcrumbs) > 0) {
                         throw MixedAnnotationWithAttributeBreadcrumbsException::forClassMethod($class->name, $method->name);


### PR DESCRIPTION
fixes #67 

Deprecation only gets triggered when PHP attributes are available. This is possible because v2.0 will also bump PHP to `>=8.0` and thereby will not cause errors for ones that still use an earlier version of PHP.

The current test suite triggers 4 deprecations, so we set `SYMFONY_DEPRECATIONS_HELPER` to `max[self]=4`

## Result when running test suite

![image](https://user-images.githubusercontent.com/2707563/141954850-30170a4c-6af1-4c28-87ce-9c68972440a6.png)
