### PR TITLE
support breadcrumbs on invokable controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ $ make test-php73
 $ make test-php74-lowest
 ```
 
+In case all test suites pass but running tests still returns an error code, that
+might be related to the number of allowed deprecations. Make sure that the
+`SYMFONY_DEPRECATIONS_HELPER` value of `max[self]` as found in `phpunit.xml.dist`
+matches the "Remaining self deprecation notices" count from the test runner output.
+
 ## Code style
 
 PHP-CS-Fixer is used to keep the code style in shape. There is a make target that uses Docker to fix

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,7 +14,7 @@
         <ini name="intl.default_locale" value="en" />
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=4" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=6" />
         <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT " value="1" />
     </php>
 

--- a/src/EventListener/BreadcrumbListener.php
+++ b/src/EventListener/BreadcrumbListener.php
@@ -47,12 +47,13 @@ class BreadcrumbListener
      */
     public function onKernelController(KernelEvent $event)
     {
-        if (!\is_array($controller = $event->getController())) {
-            return;
-        }
+        $controller = $event->getController();
+
+        $reflectableClass = \is_array($controller) ? $controller[0] : \get_class($controller);
+        $reflectableMethod = \is_array($controller) ? $controller[1] : '__invoke';
 
         // Annotations from class
-        $class = new \ReflectionClass($controller[0]);
+        $class = new \ReflectionClass($reflectableClass);
 
         // Manage JMSSecurityExtraBundle proxy class
         if (false !== $className = $this->getRealClass($class->getName())) {
@@ -83,7 +84,7 @@ class BreadcrumbListener
             $this->addBreadcrumbsToTrail($classBreadcrumbs);
 
             // Annotations from method
-            $method = $class->getMethod($controller[1]);
+            $method = $class->getMethod($reflectableMethod);
             $methodBreadcrumbs = $this->reader->getMethodAnnotations($method);
             if ($this->supportsLoadingAttributes()) {
                 $methodAttributeBreadcrumbs = $this->getAttributes($method);

--- a/tests/EventListener/BreadcrumbListenerTest.php
+++ b/tests/EventListener/BreadcrumbListenerTest.php
@@ -7,6 +7,7 @@ use APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail;
 use APY\BreadcrumbTrailBundle\Fixtures\ControllerWithAnnotations;
 use APY\BreadcrumbTrailBundle\Fixtures\ControllerWithAttributes;
 use APY\BreadcrumbTrailBundle\Fixtures\ControllerWithAttributesAndAnnotations;
+use APY\BreadcrumbTrailBundle\Fixtures\InvokableControllerWithAnnotations;
 use APY\BreadcrumbTrailBundle\MixedAnnotationWithAttributeBreadcrumbsException;
 use Nyholm\BundleTest\AppKernel;
 use Nyholm\BundleTest\BaseBundleTestCase;
@@ -74,6 +75,17 @@ class BreadcrumbListenerTest extends BaseBundleTestCase
         $this->listener->onKernelController($kernelEvent);
     }
 
+    public function testInvokableController()
+    {
+        $this->setUpTest();
+
+        $controller = new InvokableControllerWithAnnotations();
+        $kernelEvent = $this->createControllerEvent($controller);
+        $this->listener->onKernelController($kernelEvent);
+
+        self::assertCount(3, $this->breadcrumbTrail);
+    }
+
     protected function getBundleClass()
     {
         return APYBreadcrumbTrailBundle::class;
@@ -84,10 +96,11 @@ class BreadcrumbListenerTest extends BaseBundleTestCase
      */
     private function createControllerEvent($controller)
     {
+        $callable = \is_callable($controller) ? $controller : [$controller, 'indexAction'];
         if (Kernel::MAJOR_VERSION <= 4) {
-            return new FilterControllerEvent($this->kernel, [$controller, 'indexAction'], new Request(), HttpKernelInterface::MASTER_REQUEST);
+            return new FilterControllerEvent($this->kernel, $callable, new Request(), HttpKernelInterface::MASTER_REQUEST);
         }
 
-        return new ControllerEvent($this->kernel, [$controller, 'indexAction'], new Request(), HttpKernelInterface::MASTER_REQUEST);
+        return new ControllerEvent($this->kernel, $callable, new Request(), HttpKernelInterface::MASTER_REQUEST);
     }
 }

--- a/tests/Fixtures/InvokableControllerWithAnnotations.php
+++ b/tests/Fixtures/InvokableControllerWithAnnotations.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace APY\BreadcrumbTrailBundle\Fixtures;
+
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+/**
+ * @Breadcrumb("first-breadcrumb")
+ * @Breadcrumb("second-breadcrumb")
+ */
+class InvokableControllerWithAnnotations extends AbstractController
+{
+    /**
+     * @Breadcrumb("third-breadcrumb")
+     */
+    public function __invoke()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
closes #51

Follow-up for later: supporting breadcrumbs from closures when annotation support is dropped, as `doctrine/annotations` does not support reading annotations from closures.