### PR TITLE
Test expirmental PHP and Symfony versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,30 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.3', '7.4', '8.0']
-        symfony: ['3.4', '4.4', '5.1', '5.2', '5.3']
+        php-version: ['7.3', '7.4', '8.0']
+        symfony-version: ['3.4', '4.4', '5.1', '5.2', '5.3']
+        
+        experimental:
+          - false
+
+        include:
+          - php-version: "8.1"
+            symfony-version: '5.4'
+            experimental: true
+          - php-version: "8.1"
+            symfony-version: '6.0'
+            experimental: true
+          - php-version: "8.2"
+            symfony-version: '6.0'
+            experimental: true
+
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: ${{ matrix.php-version }}
           coverage: none
           extensions: mbstring, intl
           tools: composer:v2
@@ -31,7 +47,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Select supported Symfony version
-        run: composer require symfony/framework-bundle:"^${{ matrix.symfony }}" --no-update
+        run: composer require symfony/framework-bundle:"^${{ matrix.symfony-version }}" --no-update
 
       - name: Run tests
         run: make test
@@ -42,13 +58,24 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0']
+        php-version: ['7.2', '7.3', '7.4', '8.0']
+        
+        experimental:
+          - false
+
+        include:
+          - php-version: "8.1"
+            experimental: true
+          - php-version: "8.2"
+            experimental: true
+
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: ${{ matrix.php-version }}
           coverage: none
           extensions: mbstring, intl
           tools: composer:v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         php-version: ['7.3', '7.4', '8.0']
         symfony-version: ['3.4.*', '4.4.*', '5.1.*', '5.2.*', '5.3.*']
-        
+
         experimental:
           - false
 
@@ -45,13 +45,16 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v2
-        
+
       - name: Lower Composer minimum-stability to dev for experimental runs
         if: ${{ matrix.experimental }}
         run: composer config minimum-stability dev
 
       - name: Select supported Symfony version
-        run: composer require symfony/framework-bundle:"${{ matrix.symfony-version }}" --no-update
+        run:
+          export SYMFONY_REQUIRE=${{ matrix.symfony-version }}
+          composer global require --no-progress --no-scripts --no-plugins symfony/flex
+          composer require symfony/framework-bundle:"${{ matrix.symfony-version }}" --no-update
 
       - name: Run tests
         run: make test
@@ -59,11 +62,13 @@ jobs:
  test-lowest:
     name: Test Lowest
     runs-on: ubuntu-latest
+    env:
+        SYMFONY_DEPRECATIONS_HELPER: 'disabled=1'
     strategy:
       max-parallel: 10
       matrix:
         php-version: ['7.2', '7.3', '7.4', '8.0']
-        
+
         experimental:
           - false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['7.3', '7.4', '8.0']
-        symfony-version: ['3.4', '4.4', '5.1', '5.2', '5.3']
+        symfony-version: ['3.4.*', '4.4.*', '5.1.*', '5.2.*', '5.3.*']
         
         experimental:
           - false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
 
         include:
           - php-version: "8.1"
-            symfony-version: 'dev-5.4'
+            symfony-version: '5.4.*@dev'
             experimental: true
           - php-version: "8.1"
-            symfony-version: 'dev-6.0'
+            symfony-version: '6.0.*@dev'
             experimental: true
           - php-version: "8.2"
-            symfony-version: 'dev-6.0'
+            symfony-version: '6.0.*@dev'
             experimental: true
 
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
 
         include:
           - php-version: "8.1"
-            symfony-version: '5.4'
+            symfony-version: 'dev-5.4'
             experimental: true
           - php-version: "8.1"
-            symfony-version: '6.0'
+            symfony-version: 'dev-6.0'
             experimental: true
           - php-version: "8.2"
-            symfony-version: '6.0'
+            symfony-version: 'dev-6.0'
             experimental: true
 
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v2
+        
+      - name: Lower Composer minimum-stability to dev for experimental runs
+        if: ${{ matrix.experimental }}
+        run: composer config minimum-stability dev
 
       - name: Select supported Symfony version
         run: composer require symfony/framework-bundle:"${{ matrix.symfony-version }}" --no-update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: composer config minimum-stability dev
 
       - name: Select supported Symfony version
-        run:
+        run: |
           export SYMFONY_REQUIRE=${{ matrix.symfony-version }}
           composer global require --no-progress --no-scripts --no-plugins symfony/flex
           composer require symfony/framework-bundle:"${{ matrix.symfony-version }}" --no-update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Select supported Symfony version
-        run: composer require symfony/framework-bundle:"^${{ matrix.symfony-version }}" --no-update
+        run: composer require symfony/framework-bundle:"${{ matrix.symfony-version }}" --no-update
 
       - name: Run tests
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 	composer test
 
 test-lowest:
-	COMPOSER_PARAMS='--prefer-lowest' $(MAKE) test
+	SYMFONY_DEPRECATIONS_HELPER='disabled=1' COMPOSER_PARAMS='--prefer-lowest' $(MAKE) test
 
 test-php73-lowest:
 	docker run --rm -v $(DIR):/project -w /project webdevops/php:7.3 $(MAKE) test-lowest

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7.2",
-        "symfony/framework-bundle": "^3.4|^4.0|^5.0",
+        "symfony/framework-bundle": "^3.4|^4.0|^5.0|^6.0",
         "twig/twig": "^1.41|^2.0|^3.0",
         "symfony/deprecation-contracts": "^2.4"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,7 +14,7 @@
         <ini name="intl.default_locale" value="en" />
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=6" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
         <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT " value="1" />
     </php>
 


### PR DESCRIPTION
**Note:** make sure to squash commits on merge.

according to PHPUnit config https://github.com/sebastianbergmann/phpunit/blob/master/.github/workflows/ci.yml#L228-L247

Add PHP test runs that are allowed to fail for

* PHP 8.1 
* PHP 8.2 (nightly)

see https://github.com/marketplace/actions/setup-php-action#tada-php-support

Test Symfony branches until a stable version is tagged:

* 5.4-dev
* 6.0-dev

Changed deprecation helper to follow best-practice: https://symfony.com/doc/current/bundles/best_practices.html#continuous-integration