### PR TITLE
Support breadcrumb without parameters again for resetting trail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.8
+
+- introduce ResetBreadcrumbtrail attribute for resetting trail, prefer over empty annotation
+
 # v1.7
 
 - support breadcrumbs via PHP Attributes

--- a/src/Annotation/Breadcrumb.php
+++ b/src/Annotation/Breadcrumb.php
@@ -53,7 +53,7 @@ class Breadcrumb
     private $attributes = [];
 
     /**
-     * @param array|string         $title           title, or the legacy array that contains all annotation data
+     * @param array|string|null    $title           title, or the legacy array that contains all annotation data. Passing `null` to reset the breadcrumb trail is deprecated and will throw an exception in `2.0`.
      * @param ?string              $routeName
      * @param ?array<string,mixed> $routeParameters
      * @param bool                 $routeAbsolute
@@ -62,7 +62,7 @@ class Breadcrumb
      * @param array                $attributes
      */
     public function __construct(
-        $title,
+        $title = null,
         $routeName = null,
         $routeParameters = null,
         $routeAbsolute = null,

--- a/src/Annotation/ResetBreadcrumbTrail.php
+++ b/src/Annotation/ResetBreadcrumbTrail.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace APY\BreadcrumbTrailBundle\Annotation;
+
+/**
+ * Resets the breadcrumb trail. Can be applied on controller classes, callables, invokables and action methods.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+final class ResetBreadcrumbTrail
+{
+}

--- a/src/Resources/doc/annotation_configuration.md
+++ b/src/Resources/doc/annotation_configuration.md
@@ -284,7 +284,7 @@ Will render the following breadcrumb trail :
 
 ### Reset the trail
 
-Passing an breadcrumb without any parameter values will remove all existing
+Adding a ResetBreadcrumbTrail attribute will remove all existing
 breadcrumbs from the trail.
 
 Resetting might come in handy in case the controller class unwantedly defines
@@ -292,9 +292,10 @@ breadcrumbs already.
 
 ```php
 use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+use APY\BreadcrumbTrailBundle\Annotation\ResetBreadcrumbTrail;
 
 #[Breadcrumb("Level 1")]
-#[Breadcrumb()]
+#[ResetBreadcrumbTrail()]
 #[Breadcrumb("Level 2")]
 #[Breadcrumb("Level 3")]
 ```

--- a/tests/Annotation/BreadcrumbTest.php
+++ b/tests/Annotation/BreadcrumbTest.php
@@ -50,4 +50,15 @@ class BreadcrumbTest extends TestCase
 
         self::assertEquals($expected, $breadcrumb->getTitle());
     }
+
+    /**
+     * @deprecated passing empty constructor is deprecated since 1.8. ResetBreadcrumbTrail attribute should be used instead. Will throw exception in 2.0.
+     */
+    public function testConstructorWithoutArgumentsIsAllowedForResettingTrail()
+    {
+        $expected = null;
+        $breadcrumb = new Breadcrumb();
+
+        self::assertEquals($expected, $breadcrumb->getTitle());
+    }
 }

--- a/tests/EventListener/BreadcrumbListenerTest.php
+++ b/tests/EventListener/BreadcrumbListenerTest.php
@@ -8,6 +8,7 @@ use APY\BreadcrumbTrailBundle\Fixtures\ControllerWithAnnotations;
 use APY\BreadcrumbTrailBundle\Fixtures\ControllerWithAttributes;
 use APY\BreadcrumbTrailBundle\Fixtures\ControllerWithAttributesAndAnnotations;
 use APY\BreadcrumbTrailBundle\Fixtures\InvokableControllerWithAnnotations;
+use APY\BreadcrumbTrailBundle\Fixtures\ResetTrailAttribute;
 use APY\BreadcrumbTrailBundle\MixedAnnotationWithAttributeBreadcrumbsException;
 use Nyholm\BundleTest\AppKernel;
 use Nyholm\BundleTest\BaseBundleTestCase;
@@ -84,6 +85,20 @@ class BreadcrumbListenerTest extends BaseBundleTestCase
         $this->listener->onKernelController($kernelEvent);
 
         self::assertCount(3, $this->breadcrumbTrail);
+    }
+
+    /**
+     * @requires PHP >= 8.0
+     */
+    public function testResetTrailAttribute()
+    {
+        $this->setUpTest();
+
+        $controller = new ResetTrailAttribute();
+        $kernelEvent = $this->createControllerEvent($controller);
+        $this->listener->onKernelController($kernelEvent);
+
+        self::assertCount(1, $this->breadcrumbTrail);
     }
 
     protected function getBundleClass()

--- a/tests/Fixtures/ResetTrailAttribute.php
+++ b/tests/Fixtures/ResetTrailAttribute.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace APY\BreadcrumbTrailBundle\Fixtures;
+
+use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+use APY\BreadcrumbTrailBundle\Annotation\ResetBreadcrumbTrail;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+#[Breadcrumb(title: 'first-breadcrumb')]
+class ResetTrailAttribute extends AbstractController
+{
+    #[ResetBreadcrumbTrail]
+    #[Breadcrumb(title: 'first-breadcrumb-again')]
+    public function indexAction()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
And introduce `ResetBreadcrumbTrail` as preferred alternative. This deprecates having breadcrumbs without title parameter.