### PR TITLE
Fix twig cve for 1.x branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "conflict": {
         "symfony/framework-bundle": "<3.4.26 || >4 <4.1.12 || >4.2 <4.2.7",
-        "twig/twig": ">=2.0 <2.15.3"
+        "twig/twig": "<1.38 || >=2.0 <2.15.3"
     },
     "autoload-dev": {
         "psr-4": { "APY\\BreadcrumbTrailBundle\\": "tests/" }


### PR DESCRIPTION
The CVE fix of tag v1.9.0 did not cover the Twig 1.x branch. This PR fixes that.