### PR TITLE
Fixed #92 - Update dependencies to symfony v7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7.2",
-        "symfony/framework-bundle": "^4.4|^5.0|^6.0",
+        "symfony/framework-bundle": "^6.0|^7.0",
         "twig/twig": "^2.15|^3.0",
         "symfony/deprecation-contracts": "^2.4|^3.0"
     },
@@ -23,10 +23,10 @@
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^5.0|^6.0",
-        "nyholm/symfony-bundle-test": "^v2.0",
+        "nyholm/symfony-bundle-test": "^3.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "doctrine/doctrine-bundle": "^v1.0|^v2.0",
-        "doctrine/annotations": "^v1.7",
+        "doctrine/annotations": "^2.0",
         "symfony/twig-bundle": "^3.4|^4.0|^5.0|^6.0"
     },
     "autoload-dev": {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     #[\ReturnTypeWillChange]
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('apy_breadcrumb_trail');
         // BC layer for symfony/config < 4.2

--- a/src/EventListener/BreadcrumbListener.php
+++ b/src/EventListener/BreadcrumbListener.php
@@ -70,7 +70,7 @@ class BreadcrumbListener
             throw new \InvalidArgumentException(sprintf('Annotations from class "%s" cannot be read as it is abstract.', $class));
         }
 
-        if (HttpKernelInterface::MASTER_REQUEST == $event->getRequestType()) {
+        if (HttpKernelInterface::MAIN_REQUEST  == $event->getRequestType()) {
             $this->breadcrumbTrail->reset();
 
             // Annotations from class

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -19,5 +19,14 @@
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" priority="-1" />
         </service>
         <service id="apy_breadcrumb_trail.annotation.listener" alias="APY\BreadcrumbTrailBundle\EventListener\BreadcrumbListener" public="true" />
+
+                <!-- Definición del servicio AnnotationReader -->
+        <service id="Doctrine\Common\Annotations\AnnotationReader" />
+
+        <!-- Definición del servicio BreadcrumbListener -->
+        <service id="APY\BreadcrumbTrailBundle\EventListener\BreadcrumbListener">
+            <argument type="service" id="Doctrine\Common\Annotations\AnnotationReader" />
+            <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" priority="-1" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
This update removes the use of Annotations (e.g., @Breadcrumb("Level 1")) and now requires the use of Attributes (e.g., #[Breadcrumb(title: 'Level 1')]). There are some deprecations in the code that should be addressed.